### PR TITLE
check for existence of other instance of simple_html_dom 

### DIFF
--- a/versions/versions.php
+++ b/versions/versions.php
@@ -172,7 +172,9 @@ class Versions
 	 */
 	public static function filter_output( $buffer )
 	{
-		include_once('simple_html_dom.php');
+		if (!class_exists('simple_html_dom_node')) {
+			include_once('simple_html_dom.php');
+		}
 		
 		$catchAll = get_option('versions_catch_all_setting');
 		


### PR DESCRIPTION
Check for existence of the simple_html_dom class before including simple_html_dom.php in order to avoid conflicts with other instances of that library